### PR TITLE
BHC-24 - Extra Element in Children

### DIFF
--- a/src/architecture/hooks/use-rendered-markup/use-rendered-markup.hook.tsx
+++ b/src/architecture/hooks/use-rendered-markup/use-rendered-markup.hook.tsx
@@ -4,15 +4,28 @@ import { createDataProperties } from '../../functions/create-data-properties.ts'
 import type { RenderedMarkupProps } from './use-rendered-markup.props.ts';
 
 const useRenderedMarkup = <RP = undefined, P = undefined>({
-  children,
+  wrapperElement,
   renderProps,
   elementProps,
-  wrapperElement,
-  className
+  innerWrapperElement,
+  className,
+  children,
 }: RenderedMarkupProps<RP, P>): React.JSX.Element | TypeOrArray<ReactNode> => {
   if (typeof children === 'function') {
-    return children(renderProps);
+    return innerWrapperElement ? (
+      <>
+        {innerWrapperElement}
+        {children(renderProps)}
+      </>
+    ) : children(renderProps);
   } else {
+    const finalChildren = innerWrapperElement ? (
+      <>
+        {innerWrapperElement}
+        {children}
+      </>
+    ) : children;
+
     return createElement(
       wrapperElement,
       Object.assign(
@@ -23,7 +36,7 @@ const useRenderedMarkup = <RP = undefined, P = undefined>({
           className
         },
       ),
-      children
+      finalChildren
     );
   }
 };

--- a/src/architecture/hooks/use-rendered-markup/use-rendered-markup.props.ts
+++ b/src/architecture/hooks/use-rendered-markup/use-rendered-markup.props.ts
@@ -1,8 +1,8 @@
-import type { ElementType } from 'react';
+import type { ElementType, JSX, ReactNode } from 'react';
 import type { ChildrenType } from '../../headless-interfaces.ts';
 
 export interface RenderedMarkupProps<RP = undefined, P = undefined> {
-  children: ChildrenType<RP>;
+  wrapperElement: ElementType;
   /**
    * When a render function is used this object will be passed as a parameter, when a child node is used the values set
    * in this object will be added to the wrapper element as `data-*` properties.
@@ -13,6 +13,11 @@ export interface RenderedMarkupProps<RP = undefined, P = undefined> {
    * properties.
    */
   elementProps?: P;
-  wrapperElement: ElementType;
+  /**
+   * Allows an element to be set in the children parameter without affecting the functionality of a child render
+   * function.
+   */
+  innerWrapperElement?: JSX.Element | ReactNode;
   className?: string;
+  children: ChildrenType<RP>;
 }

--- a/src/components/common/field/field.component.tsx
+++ b/src/components/common/field/field.component.tsx
@@ -4,7 +4,7 @@ import {
   type FieldContextProps
 } from 'architecture/hooks/use-field-context/use-field-context.props.ts';
 import type { FieldProps } from './field.props.ts';
-import { useRenderedMarkup } from 'architecture/hooks/use-rendered-markup/use-rendered-markup.hook.ts';
+import { useRenderedMarkup } from 'architecture/hooks/use-rendered-markup/use-rendered-markup.hook.tsx';
 
 const Field = ({ className, children }: FieldProps) => {
   // this will be used to associate a control with something like a label...use a context to share this

--- a/src/components/common/label/label.component.tsx
+++ b/src/components/common/label/label.component.tsx
@@ -1,7 +1,7 @@
 import { useMemo } from 'react';
 import { useFieldContextHook } from 'architecture/hooks/use-field-context/use-field-context.hook.ts';
 import type { LabelElementProps, LabelProps } from './label.props.ts';
-import { useRenderedMarkup } from 'architecture/hooks/use-rendered-markup/use-rendered-markup.hook.ts';
+import { useRenderedMarkup } from 'architecture/hooks/use-rendered-markup/use-rendered-markup.hook.tsx';
 
 const Label = ({ htmlFor, className, children }: LabelProps) => {
   const fieldContext = useFieldContextHook();

--- a/src/components/form/checkboxes/checkbox/checkbox.component.tsx
+++ b/src/components/form/checkboxes/checkbox/checkbox.component.tsx
@@ -12,11 +12,13 @@ import React, {
 import { useFieldContextHook } from 'architecture/hooks/use-field-context/use-field-context.hook.ts';
 import type {
   CheckboxCheckState,
+  CheckboxElementProps,
   CheckboxProps,
-  CheckboxRef, CheckboxRenderProps,
+  CheckboxRef,
+  CheckboxRenderProps,
 } from './checkbox.props.ts';
 import { HiddenField } from 'architecture/components/hidden-field/hidden-field.component.tsx';
-import { useRenderedMarkup } from 'architecture/hooks/use-rendered-markup/use-rendered-markup.hook.ts';
+import { useRenderedMarkup } from 'architecture/hooks/use-rendered-markup/use-rendered-markup.hook.tsx';
 
 const CheckboxComponent = (props: CheckboxProps, ref: Ref<CheckboxRef>) => {
   const { name, value, checked = false, partial = false, readOnly, onChange, children, className } = props;
@@ -90,29 +92,30 @@ const CheckboxComponent = (props: CheckboxProps, ref: Ref<CheckboxRef>) => {
     setChecked,
   }));
 
-  const component = useRenderedMarkup<CheckboxRenderProps>({
-    wrapperElement: 'span',
+  const hiddenField = (
+    <HiddenField
+      id={finalId}
+      name={name}
+      type="checkbox"
+      checked={checkedState.value.checked}
+      readOnly={readOnly}
+      onChange={handleChangeEvent}
+    />
+  );
+
+  return useRenderedMarkup<CheckboxRenderProps, CheckboxElementProps>({
+    wrapperElement: 'label',
     renderProps: {
       ...checkedState.value,
       readOnly,
     },
+    elementProps: {
+      htmlFor: finalId,
+    },
     className,
+    innerWrapperElement: hiddenField,
     children
   });
-
-  return (
-    <>
-      <HiddenField
-        id={finalId}
-        name={name}
-        type="checkbox"
-        checked={checkedState.value.checked}
-        readOnly={readOnly}
-        onChange={handleChangeEvent}
-      />
-      {component}
-    </>
-  );
 };
 
 const Checkbox = memo(forwardRef(CheckboxComponent));

--- a/src/components/form/checkboxes/checkbox/checkbox.props.ts
+++ b/src/components/form/checkboxes/checkbox/checkbox.props.ts
@@ -13,6 +13,10 @@ export interface CheckboxRenderProps {
   readOnly?: boolean;
 }
 
+export interface CheckboxElementProps {
+  htmlFor: string;
+}
+
 export interface CheckboxProps extends MakeRequired<FormInputControl<unknown, CheckboxChangeEvent>, 'name'> {
   checked?: boolean;
   partial?: boolean;


### PR DESCRIPTION
Added a feature to allow extra markup inside the wrapper element that is not directly passed through the children property. This is useful in the case where a hidden field needs to be inside the wrapper element for features like focus styles to work properly